### PR TITLE
SO-7798 Add missing histogram rollup parameter

### DIFF
--- a/irondb/getting-started/configuration.md
+++ b/irondb/getting-started/configuration.md
@@ -638,6 +638,7 @@ wipe and reconstitute each node in order to apply new settings.
               granularity="7d"
               min_delete_age="4w"
               delete_after_quiescent_age="1d"
+              rollup_after_quiescent_age="8h"
               max_clock_skew="1w"
 />
 ```
@@ -672,6 +673,15 @@ written to, may be deleted.
 
 Default: 1 day
 
+#### histogram_ingest rollup_after_quiescent_age
+
+The period the system will delay after the last write to a shard before
+attempting to roll it up.   New writes to the time period/shard will interrupt the
+rollup process and reset the quiescent timer which must again reach the
+`rollup_after_quiescent_age` before a re-roll will be attempted.
+
+Default: 8 hours
+
 #### histogram_ingest max_clock_skew
 
 Allow the submission of metrics timestamped up to this amount of time in the
@@ -681,7 +691,7 @@ Default: 1 week
 
 ### histogram
 ```
-<histogram location="/irondb/hist_rollups/{node}" legacy_location="/irondb/hist_legacy/{node}">
+<histogram location="/irondb/hist_rollup/{node}">
   <rollup period="60" granularity="7d"/>
   <rollup period="300" granularity="30d"/>
   <rollup period="1800" granularity="12w"/>

--- a/irondb/release-notes.md
+++ b/irondb/release-notes.md
@@ -9,8 +9,10 @@ sidebar_position: 12
 
 2024-11-05
 
-**NOTE: This release deprecates legacy histograms. Histogram shards must be configured before
-upgrading to this release. If this is not done, nodes may not start up after the upgrade.**
+**NOTE: This release deprecates legacy histograms.
+[Histogram shards](/irondb/getting-started/configuration/#histogram_ingest)
+must be configured before upgrading to this release. If this is not done, nodes
+may not start up after the upgrade.**
 
  * Fix use after free bug that could occasionally happen due to a race when fetching raw data.
  * Fix potential memory leak on certain oil/activity data operations.


### PR DESCRIPTION
The `rollup_after_quiescent_age` works just like the one for raw numeric.

Link to histogram_ingest docs from the changelog warning.