### PR TITLE
OPL-11128 - Update Delete Documentation

### DIFF
--- a/irondb/api/data-deletion.md
+++ b/irondb/api/data-deletion.md
@@ -476,14 +476,13 @@ DELETE
 
 #### Headers
 
-Used with all deletes::
+Used with all deletes:
  * `x-snowth-account-id: <account_id>` (required)
    * `account_id` The account to be searched using the wildcard pattern
-Used with tag query delete:
+Used only with tag query delete:
  * `x-snowth-advisory-limit: <integer>|none` (optional, defaults to 100,000 if not present)
    * `integer` A positive integer specifying the number of matching results to
      delete. If the header is unset, the default of 100,000 will be used.
-Used only with canonical metric delete:
  * `x-snowth-confirm-delete: <0 or 1>` (optional, must be present and set to 1 to actually confirm and process the deletion)
 
 ### Single Metric Example

--- a/irondb/api/data-deletion.md
+++ b/irondb/api/data-deletion.md
@@ -106,186 +106,6 @@ In this example:
 ]
 ```
 
-## Deleting Numeric Rollup Data for a Metric or a Set of Metrics
-
-This API call is for deleting numeric rollup data from the IRONdb cluster for a specific metric or for a set of metrics (when wildcards or a tag query are specified). It will remove numeric data from the beginning of time up until the end time provided by the user for that metric(s).
-
-If using the deprecated NNT rollup storage format (as opposed to
-[NNTBS](/irondb/getting-started/configuration/##nntbs)) and the time given is greater than the most
-recent data point in the NNT file, the NNT file will be removed.
-
-The default behavior is deletion of data for all rollups, but it is possible also to specify particular rollups in the header given below, which may be used to remove data for specific rollup(s) which are not needed.
-
-When used for deletion of a single metric, this call will return an empty array on success. If there is an error, it will return a JSON object with the error.
-
-When used with wildcards or a tag query, this call always returns a JSON object which describes the matching metrics and the actions taken or errors received on the deletion.  For safety, explicit confirmation is required in the headers to actually force the data deletion.
-A list of the possible result statuses for each metric and what they mean can be found [here](/irondb/api/data-deletion#wildcard-tag-query-and-check-delete-result-statuses).
-
-**It is highly recommended to perform the deletion API call without confirmation as a first step, in order to review what would actually be deleted (and hopefully avoid accidentally deleting more data than intended).**
-
-Deletion of a single metric can optionally be journaled and replicated to all nodes using the `X-Snowth-Full-Delete` setting given for the headers below.  However, wildcard or tag query deletion is currently only supported on a single node per API call.  To use wildcards or a tag query to remove data across the cluster, issue the same API call to each node.
-
-### Description
-
-#### URI
-
-`/nnt/<uuid>/<metric>`
-
--OR-
-
-`/nnt/<uuid>/<metric_pattern_including_wildcards>`
-
--OR-
-
-`/nnt/tags?query=<query>`
-
-#### Method
-
-DELETE
-
-#### Inputs
-
- * `uuid` : The UUID of the check to which the metric belongs.
- * `metric` : The name of the metric from which to delete data.
- * `metric_pattern_including_wildcards` : A metric naming pattern string including wildcards.
- * `query` : See [Tag Queries](/irondb/metric-names-tags-queries/#tag-queries) for more info on tag queries.
-
-#### Headers
-
- * `x-snowth-delete-time: <end>` (required)
-   * `end` The end timestamp for the delete operation. All data before this specified time is deleted (if wildcards or a tag query are specified, data will only be located and deletion will not occur unless confirmation is given). Time is represented in seconds since the epoch.
- * `x-snowth-delete-rollups: <rollups>` (optional, if omitted the default is ALL rollups)
-   * `rollups` The rollups that should be included in the deletion operation, separated by commas
-
-Used only with wildcards or tag query:
- * `x-snowth-account-id: <account_id>` (required)
-   * `account_id` The account to be searched using the wildcard pattern
- * `x-snowth-advisory-limit: <integer>` (optional, defaults to no limit if not present)
-   * `integer` A positive integer specifying the number of matching results to
-     delete. If the header is unset, or set to -1 or "none", the service will
-     not limit the result set.
- * `x-snowth-confirm-delete: <0 or 1>` (optional, must be present and set to 1 to actually confirm and process the deletion)
-
-Used only without wildcards or tag query:
- * `x-snowth-full-delete: <value>` (optional)
-   * `value` Determines whether the delete operation is local to the receiving node (0) or journaled to all other nodes as well (1). The default, if not specified, is 0 (local-only delete). This setting means perform the delete across all nodes, and is not to be confused with the [full delete API](#delete-full).
-
-### Single Metric Example
-
-```
-curl -X DELETE \
-     -H 'X-Snowth-Delete-Time: 1527811200' \
-     http://127.0.0.1:8112/nnt/6f6bdc73-2352-4bdc-ab0e-72f66d0dee12/example
-```
-
-In this example:
-
- * `nnt` : This tells the system that numeric data will be removed.
- * `6f6bdc73-2352-4bdc-ab0e-72f66d0dee12` : Check UUID
- * `example` : Metric name
- * `1527811200` : Delete all data for this metric before this time
-
-#### Sample Output for Single Metric Example
-
-```
-[]
-```
-
-### Wildcard Metric Example
-
-```
-curl -X DELETE \
-     -H 'x-snowth-delete-time: 1527811200' \
-     -H 'x-snowth-account-id: 1234' \
-     -H 'x-snowth-confirm-delete: 1' \
-     http://127.0.0.1:8112/nnt/6f6bdc73-2352-4bdc-ab0e-72f66d0dee12/multiple_example*
-```
-
-In this example:
-
- * `nnt` : This tells the system that numeric data will be removed.
- * `6f6bdc73-2352-4bdc-ab0e-72f66d0dee12` : Check UUID
- * `multiple_example*` : Metric name pattern including wildcard
- * `1527811200` : Delete all data for matching metrics before this time
- * `1234` : Delete data only for the given account id
- * `1` : Confirm to actually commit to the deletion (we highly recommend omitting this header at first, to examine what will be deleted)
-
-#### Sample Output for Wildcard Metric Example
-
-```
-[ {"metric_name":"multiple_example_cpuutil_server1","delete_result":"not local","payload":""},
-  {"metric_name":"multiple_example_cpuutil_server2","delete_result":"deleted","payload":""},
-  ...
-]
-```
-
-## Deleting Numeric Data for a Check
-
-This API call is for deleting numeric data from the IRONdb cluster for an entire check. It will remove data from the beginning of time up until the time provided by the user for every numeric metric that is part of
-the given check UUID.
-
-If using the deprecated NNT rollup storage format (as opposed to
-[NNTBS](/irondb/getting-started/configuration/##nntbs)) and the time given is greater than the most
-recent data point in the NNT file, the NNT file will be removed.
-
-The default behavior is deletion of data for all rollups, but it is possible also to specify particular rollups in the header given below, which may be used to remove data for specific rollup(s) which are not needed.
-
-This call always returns a JSON object which describes the matching metrics and the actions taken or errors received on the deletion.  For safety, explicit confirmation is required in the headers to actually force the data deletion.
-A list of the possible result statuses for each metric and what they mean can be found [here](/irondb/api/data-deletion#wildcard-tag-query-and-check-delete-result-statuses).
-
-**It is highly recommended to perform the deletion API call without confirmation as a first step, in order to review what would actually be deleted (and hopefully avoid accidentally deleting more data than intended).**
-
-Deletion is currently only supported on a single node per API call.  To delete data from the entire cluster, issue the same API call to each node.
-
-### Description
-
-#### URI
-
-`/nnt/<uuid>`
-
-#### Method
-
-DELETE
-
-#### Inputs
-
- * `uuid` The UUID of the check.
-
-#### Headers
-
- * `x-snowth-delete-time: <end>` (required)
-   * `end` The end timestamp for the delete operation. All data before this specified time is deleted. Time is represented in seconds since the epoch.
- * `x-snowth-account-id: <account_id>` (required)
-   * `account_id` The account to be searched using the wildcard pattern
- * `x-snowth-delete-rollups: <rollups>` (optional, if omitted the default is ALL rollups)
-   * `rollups` The rollups that should be included in the deletion operation, separated by commas
- * `x-snowth-confirm-delete: <0 or 1>` (optional, must be present and set to 1 to actually confirm and process the deletion)
-
-### Examples
-
-```
-curl -X DELETE \
-     -H 'x-snowth-delete-time: 1527811200' \
-     -H 'x-snowth-account-id: 1234' \
-     -H 'x-snowth-confirm-delete: 1' \
-     http://127.0.0.1:8112/nnt/6f6bdc73-2352-4bdc-ab0e-72f66d0dee12
-```
-
-In this example:
-
- * `nnt` : This tells the system that nnt data will be removed.
- * `6f6bdc73-2352-4bdc-ab0e-72f66d0dee12` : Check UUID
- * `1527811200` : Delete all data for this check before this time
-
-#### Output
-
-```
-[ {"metric_name":"multiple_example_cpuutil_server1","delete_result":"not local","payload":""},
-  {"metric_name":"multiple_example_cpuutil_server2","delete_result":"deleted","payload":""},
-  ...
-]
-```
-
 ## Deleting Text Data for a Metric or a Set of Metrics
 
 This API call is for deleting text data from the IRONdb cluster for a specific metric or for a set of metrics (when wildcards or a tag query are specified). It will remove text data from the beginning of time up until the end time provided by the user for that metric(s).
@@ -622,9 +442,9 @@ In this example:
 
 ## Deleting All Data for a Metric or a Set of Metrics
 
-This API call is for deleting all of the data from an IRONdb node for a specific metric or for a set of metrics (when wildcards or a tag query are specified). It will remove data for the matching metric(s) throughout all timestamps and all rollups that have been provided by the user, no matter what the data type.  In addition, it will remove all record of the metric name(s) with their tags and metadata.  This call is intended for removing misnamed/experimental metrics or old metrics which are obsolete and can be safely removed.
+This API call is for deleting all of the data from an IRONdb node for a specific metric or for a set of metrics (when a tag query is specified). It will remove data for the matching metric(s) throughout all timestamps and all rollups that have been provided by the user, no matter what the data type.  In addition, it will remove all record of the metric name(s) with their tags and metadata.  This call is intended for removing misnamed/experimental metrics or old metrics which are obsolete and can be safely removed.
 
-When used for deletion of a single metric, this call will return an empty array on success. If there is an error, it will return a JSON object with the error.
+When used for deletion of a single metric, this call will return a JSON object that reports if the request succeeded or not.
 
 When used with wildcards or a tag query, this call always returns a JSON object which describes the matching metrics and the actions taken or errors received on the deletion.
 A list of the possible result statuses for each metric and what they mean can be found [here](/irondb/api/data-deletion#wildcard-tag-query-and-check-delete-result-statuses).
@@ -638,11 +458,7 @@ Deletion is currently only supported on a single node per API call.  To delete d
 
 #### URI
 
-`/full/<uuid>/<metric>`
-
--OR-
-
-`/full/<uuid>/<metric_pattern_including_wildcards>`
+`/full/canonical/<uuid>/<metric>`
 
 -OR-
 
@@ -655,69 +471,72 @@ DELETE
 #### Inputs
 
  * `uuid` : The UUID of the check to which the metric belongs.
- * `metric` : The name of the metric from which data is deleted.
- * `metric_pattern_including_wildcards` : A metric naming pattern string including wildcards.
+ * `metric` : The full canonical name of the metric from which data is deleted, including tags.
  * `query` : See [Tag Queries](/irondb/metric-names-tags-queries/#tag-queries) for more info on tag queries.
 
 #### Headers
 
-Used only with wildcards or tag query:
+Used with all deletes::
  * `x-snowth-account-id: <account_id>` (required)
    * `account_id` The account to be searched using the wildcard pattern
- * `x-snowth-advisory-limit: <integer>|none` (optional, defaults to no limit if not present)
+Used on with tag query delete:
+ * `x-snowth-advisory-limit: <integer>|none` (optional, defaults to 100,000 if not present)
    * `integer` A positive integer specifying the number of matching results to
-     delete. If the header is unset, or set to -1 or "none", the service will
-     not limit the result set.
+     delete. If the header is unset, the default of 100,000 will be used.
+Used only with canonical metric delete:
  * `x-snowth-confirm-delete: <0 or 1>` (optional, must be present and set to 1 to actually confirm and process the deletion)
 
 ### Single Metric Example
 
 ```
 curl -X DELETE \
-     http://127.0.0.1:8112/full/6f6bdc73-2352-4bdc-ab0e-72f66d0dee12/example
+     -H 'x-snowth-account-id: 1234' \
+     http://127.0.0.1:8112/full/canonical/6f6bdc73-2352-4bdc-ab0e-72f66d0dee12/example
 ```
 
 In this example:
 
  * `full` : This tells the system that full data and metadata will be removed for the specified metric.
+ * `canonical` : This tells the system to delete a single metric that matches the given UUID and metric name.
+ * `1234` : Delete data only for the given account id
  * `6f6bdc73-2352-4bdc-ab0e-72f66d0dee12` : Check UUID
  * `example` : Metric name
- * `1527811200` : Delete all data for this metric before this time
 
 #### Sample Output for Single Metric Example
 
 ```
-[]
+{ "status": "succeeded" }
 ```
 
-### Wildcard Metric Example
+### Query Example
 
 ```
 curl -X DELETE \
      -H 'x-snowth-account-id: 1234' \
      -H 'x-snowth-confirm-delete: 1' \
-     http://127.0.0.1:8112/full/6f6bdc73-2352-4bdc-ab0e-72f66d0dee12/multiple_example*
+     http://127.0.0.1:8112/full/tags/query=and(__check_uuid:6f6bdc73-2352-4bdc-ab0e-72f66d0dee12,__name:multiple_example*)
 ```
 
 In this example:
 
  * `full` : This tells the system that all data and metadata for the matching metrics will be removed.
- * `6f6bdc73-2352-4bdc-ab0e-72f66d0dee12` : Check UUID
- * `multiple_example*` : Metric name pattern including wildcard
- * `1527811200` : Delete all data for matching metrics before this time
+ * `tags` : This tells the system that this is a tag query.
  * `1234` : Delete data only for the given account id
  * `1` : Confirm to actually commit to the deletion (we highly recommend omitting this header at first, to examine what will be deleted)
+ * `query` : See [Tag Queries](/irondb/metric-names-tags-queries/#tag-queries) for more info on tag queries.
+ * `6f6bdc73-2352-4bdc-ab0e-72f66d0dee12`: The UUID to match.
+ * `multiple_example*`: The metric name to match, with `*` denoting a wildcard.
 
-#### Sample Output for Wildcard Metric Example
+#### Sample Output for Query Example
 
 ```
 [ {"metric_name":"multiple_example_cpuutil_server1","delete_result":"not local","payload":""},
-  {"metric_name":"multiple_example_cpuutil_server2","delete_result":"deleted","payload":""},
+  {"metric_name":"multiple_example_cpuutil_server2","delete_result":"ok","payload":""},
   ...
 ]
 ```
 
-## Wildcard, Tag Query and Check Delete Result Statuses
+## Tag Query and Check Delete Result Statuses
 
 When doing a delete which could affect multiple metrics, the returned JSON response will indicate the final status for each metric which matched the request.  A list of these statuses and a description is given below.  Note that, in many cases, the "payload' field will contain further details.
 

--- a/irondb/api/data-deletion.md
+++ b/irondb/api/data-deletion.md
@@ -536,7 +536,7 @@ In this example:
 ]
 ```
 
-## Tag Query and Check Delete Result Statuses
+## Wildcard, Tag Query and Check Delete Result Statuses
 
 When doing a delete which could affect multiple metrics, the returned JSON response will indicate the final status for each metric which matched the request.  A list of these statuses and a description is given below.  Note that, in many cases, the "payload' field will contain further details.
 

--- a/irondb/api/data-deletion.md
+++ b/irondb/api/data-deletion.md
@@ -479,7 +479,7 @@ DELETE
 Used with all deletes::
  * `x-snowth-account-id: <account_id>` (required)
    * `account_id` The account to be searched using the wildcard pattern
-Used on with tag query delete:
+Used with tag query delete:
  * `x-snowth-advisory-limit: <integer>|none` (optional, defaults to 100,000 if not present)
    * `integer` A positive integer specifying the number of matching results to
      delete. If the header is unset, the default of 100,000 will be used.

--- a/irondb/api/data-deletion.md
+++ b/irondb/api/data-deletion.md
@@ -514,7 +514,7 @@ In this example:
 curl -X DELETE \
      -H 'x-snowth-account-id: 1234' \
      -H 'x-snowth-confirm-delete: 1' \
-     http://127.0.0.1:8112/full/tags/query=and(__check_uuid:6f6bdc73-2352-4bdc-ab0e-72f66d0dee12,__name:multiple_example*)
+     http://127.0.0.1:8112/full/tags?query=and(__check_uuid:6f6bdc73-2352-4bdc-ab0e-72f66d0dee12,__name:multiple_example*)
 ```
 
 In this example:


### PR DESCRIPTION
Much of the data delete documentation was either out of date or incorrect.

Removed the NNT delete documentation as that is no longer used and updated the full delete documentation to be correct.

It is likely there is still some incorrect data in the text and histogram delete calls, as things have changed a lot without changing the existing documentation, but this fixes the known issues that I found.